### PR TITLE
fix(windows): fix aero-snap and allow resizing for borderless window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - On Web, added support for `DeviceEvent::MouseMotion` to listen for relative mouse movements.
 - Added `Window::drag_window`. Implemented on Windows, macOS, X11 and Wayland.
 - On X11, bump `mio` to 0.7.
+- On Windows, fix aero-snap for borderless(undecorated) window.
+- On Windows, allow resizing of borderless(undecorated) window.
 
 # 0.24.0 (2020-12-09)
 

--- a/examples/drag_window.rs
+++ b/examples/drag_window.rs
@@ -11,10 +11,7 @@ fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window_1 = WindowBuilder::new()
-        .with_decorations(false)
-        .build(&event_loop)
-        .unwrap();
+    let window_1 = WindowBuilder::new().build(&event_loop).unwrap();
     let window_2 = WindowBuilder::new().build(&event_loop).unwrap();
 
     let mut switched = false;

--- a/examples/drag_window.rs
+++ b/examples/drag_window.rs
@@ -11,7 +11,10 @@ fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window_1 = WindowBuilder::new().build(&event_loop).unwrap();
+    let window_1 = WindowBuilder::new()
+        .with_decorations(false)
+        .build(&event_loop)
+        .unwrap();
     let window_2 = WindowBuilder::new().build(&event_loop).unwrap();
 
     let mut switched = false;

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -26,9 +26,11 @@ fn main() {
     eprintln!("  (Q) Quit event loop");
     eprintln!("  (V) Toggle visibility");
     eprintln!("  (X) Toggle maximized");
+    eprintln!("  (B) Toggle Borderless");
 
     let mut minimized = false;
     let mut visible = true;
+    let mut borderless = false;
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
@@ -110,6 +112,10 @@ fn main() {
                     VirtualKeyCode::X => {
                         let is_maximized = window.is_maximized();
                         window.set_maximized(!is_maximized);
+                    }
+                    VirtualKeyCode::B => {
+                        borderless = !borderless;
+                        window.set_decorations(borderless);
                     }
                     _ => (),
                 },

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -26,7 +26,7 @@ fn main() {
     eprintln!("  (Q) Quit event loop");
     eprintln!("  (V) Toggle visibility");
     eprintln!("  (X) Toggle maximized");
-    eprintln!("  (B) Toggle Borderless");
+    eprintln!("  (B) Toggle borderless");
 
     let mut minimized = false;
     let mut visible = true;

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1962,9 +1962,9 @@ unsafe fn public_window_callback_inner<T: 'static>(
         }
 
         winuser::WM_NCCALCSIZE => {
-            let window_state = subclass_input.window_state.lock();
+            let win_flags = subclass_input.window_state.lock().window_flags();
 
-            if !window_state.window_flags.contains(WindowFlags::DECORATIONS) {
+            if !win_flags.contains(WindowFlags::DECORATIONS) {
                 // adjust the maximized borderless window fill the work area rectangle of the display monitor
                 if util::is_maximized(window) {
                     let monitor = monitor::current_monitor(window);
@@ -1989,11 +1989,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 },
             };
 
-            let window_state = subclass_input.window_state.lock();
+            let win_flags = subclass_input.window_state.lock().window_flags();
 
             // Only apply this hit test for borderless windows that wants to be resizable
-            if !window_state.window_flags.contains(WindowFlags::DECORATIONS)
-                && window_state.window_flags.contains(WindowFlags::RESIZABLE)
+            if !win_flags.contains(WindowFlags::DECORATIONS)
+                && win_flags.contains(WindowFlags::RESIZABLE)
             {
                 // cursor location
                 let (cx, cy) = (

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1965,7 +1965,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             let win_flags = subclass_input.window_state.lock().window_flags();
 
             if !win_flags.contains(WindowFlags::DECORATIONS) {
-                // adjust the maximized borderless window fill the work area rectangle of the display monitor
+                // adjust the maximized borderless window to fill the work area rectangle of the display monitor
                 if util::is_maximized(window) {
                     let monitor = monitor::current_monitor(window);
                     if let Ok(monitor_info) = monitor::get_monitor_info(monitor.hmonitor()) {
@@ -1973,7 +1973,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                         params.rgrc[0] = monitor_info.rcWork;
                     }
                 }
-                0 // must return a value here, other wise the window won't be borderless (without decorations)
+                0 // must return a value here, otherwise the window won't be borderless (without decorations)
             } else {
                 commctrl::DefSubclassProc(window, msg, wparam, lparam)
             }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1983,9 +1983,8 @@ unsafe fn public_window_callback_inner<T: 'static>(
             use {
                 winapi::shared::minwindef::TRUE,
                 winuser::{
-                    GetSystemMetrics, GetWindowRect, HTBOTTOM, HTBOTTOMLEFT, HTBOTTOMRIGHT,
-                    HTCLIENT, HTLEFT, HTNOWHERE, HTRIGHT, HTTOP, HTTOPLEFT, HTTOPRIGHT, SM_CXFRAME,
-                    SM_CXPADDEDBORDER, SM_CYFRAME,
+                    GetWindowRect, HTBOTTOM, HTBOTTOMLEFT, HTBOTTOMRIGHT, HTCLIENT, HTLEFT,
+                    HTNOWHERE, HTRIGHT, HTTOP, HTTOPLEFT, HTTOPRIGHT,
                 },
             };
 
@@ -2001,12 +2000,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     windowsx::GET_Y_LPARAM(lparam),
                 );
 
-                // border size
-                let (bx, by) = (
-                    GetSystemMetrics(SM_CXFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER),
-                    GetSystemMetrics(SM_CYFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER),
-                );
-
                 let mut window_rect: RECT = mem::zeroed();
                 if GetWindowRect(window, <*mut _>::cast(&mut window_rect)) == TRUE {
                     const CLIENT: i32 = 0b0000;
@@ -2019,6 +2012,8 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     const BOTTOMLEFT: i32 = BOTTOM | LEFT;
                     const BOTTOMRIGHT: i32 = BOTTOM | RIGHT;
 
+                    let fake_border = 5; // change this to manipulate how far inside the window, the resize can happen
+
                     let RECT {
                         left,
                         right,
@@ -2026,10 +2021,10 @@ unsafe fn public_window_callback_inner<T: 'static>(
                         top,
                     } = window_rect;
 
-                    let result = LEFT * (if cx < (left + bx) { 1 } else { 0 })
-                        | RIGHT * (if cx >= (right - bx) { 1 } else { 0 })
-                        | TOP * (if cy < (top + by) { 1 } else { 0 })
-                        | BOTTOM * (if cy >= (bottom - by) { 1 } else { 0 });
+                    let result = LEFT * (if cx < (left + fake_border) { 1 } else { 0 })
+                        | RIGHT * (if cx >= (right - fake_border) { 1 } else { 0 })
+                        | TOP * (if cy < (top + fake_border) { 1 } else { 0 })
+                        | BOTTOM * (if cy >= (bottom - fake_border) { 1 } else { 0 });
 
                     match result {
                         CLIENT => HTCLIENT,

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -196,6 +196,15 @@ pub fn is_focused(window: HWND) -> bool {
     window == unsafe { winuser::GetActiveWindow() }
 }
 
+pub fn is_maximized(window: HWND) -> bool {
+    unsafe {
+        let mut placement: winuser::WINDOWPLACEMENT = mem::zeroed();
+        placement.length = mem::size_of::<winuser::WINDOWPLACEMENT>() as u32;
+        winuser::GetWindowPlacement(window, &mut placement);
+        return placement.showCmd == winuser::SW_MAXIMIZE as u32;
+    }
+}
+
 impl CursorIcon {
     pub(crate) fn to_windows_cursor(self) -> *const wchar_t {
         match self {

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -201,7 +201,7 @@ pub fn is_maximized(window: HWND) -> bool {
         let mut placement: winuser::WINDOWPLACEMENT = mem::zeroed();
         placement.length = mem::size_of::<winuser::WINDOWPLACEMENT>() as u32;
         winuser::GetWindowPlacement(window, &mut placement);
-        return placement.showCmd == winuser::SW_MAXIMIZE as u32;
+        placement.showCmd == winuser::SW_MAXIMIZE as u32
     }
 }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -120,6 +120,20 @@ impl Window {
                 };
 
                 event_loop::subclass_window(win.window.0, subclass_input);
+
+                // seems like the subclass is attached after the window is visible to the user and ther is some sort of a gab
+                // and now that borderless windows are created by reacting to `WM_NCCALCSIZE` and `WM_NCHITTEST`,
+                // the border/titlebar/decorations will still be visible unless the window is resized or maximized
+                // so we increases the window size by one pixel then revert it back
+                let win_flags = win.window_state.lock().window_flags();
+                if !win_flags.contains(WindowFlags::DECORATIONS) {
+                    let original = win.inner_size();
+                    win.set_inner_size(
+                        PhysicalSize::new(original.width + 1, original.height).into(),
+                    );
+                    win.set_inner_size(original.into());
+                }
+
                 win
             })
         }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -197,6 +197,8 @@ impl WindowFlags {
         if self.contains(WindowFlags::DECORATIONS) {
             style |= WS_CAPTION | WS_MINIMIZEBOX | WS_BORDER;
             style_ex = WS_EX_WINDOWEDGE;
+        } else {
+            style |= WS_CAPTION | WS_MAXIMIZEBOX | WS_MINIMIZEBOX | WS_SIZEBOX;
         }
         if self.contains(WindowFlags::VISIBLE) {
             style |= WS_VISIBLE;


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [X] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
